### PR TITLE
hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ nx.draw_networkx_edges(G,pos=pos)
 
 In this example, we consider the SIR model on a chain. Node number 5 is immuned
 and node 0 is initially infected. We illustrate the set of recovered nodes at the end of the process.
+
+***Note :*** this immunization method is more efficient for sampling than directly changing
+the structure (removing edges connected to an immuned node). Indeed, one can
+keep the same object `SpreadingProcess` all along.
 ```python
 from spreading_CR import SpreadingProcess
 import numpy as np

--- a/src/StaticNetworkSIR.cpp
+++ b/src/StaticNetworkSIR.cpp
@@ -55,7 +55,7 @@ StaticNetworkSIR::StaticNetworkSIR(
     {
         if (waning_immunity_rate_ > 0)
         {
-            if (isinf(waning_immunity_rate_))
+            if (std::isinf(waning_immunity_rate_))
             {
                 is_SIS_ = true;
             }
@@ -253,7 +253,7 @@ void StaticNetworkSIR::set_recovered(NodeLabel node)
     }
     else
     {
-        cout << "The model does not allow recovered nodes" << endl;
+        cout << "This model version does not allow recovered nodes" << endl;
     }
 }
 


### PR DESCRIPTION
-Changed isinf to std::isinf in file StaticNetworkSIR.cpp for compatibility issues. 
-Clarified the error message for SIS model not accepting recovered nodes. 
-Highlight the efficient feature of immunizaton in the README.